### PR TITLE
put min.js in body

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,6 @@ app.listen(app.get('port'), function() {
 })
 
 app.get("/",function(req,res) {
-  res.send('<html><head><script src="/min.js"></script><link href="/min.css"/></head><body></body></html>')
+  res.send('<html><head><link rel="stylesheet" href="/min.css"/></head><body><script src="/min.js"></script></body></html>')
 })
 


### PR DESCRIPTION
the min.js script needed to be in the body of the html in order for the backbone to recognize the 'body' as an el
